### PR TITLE
Added feature for bind_feat to bind with a set and non string values.

### DIFF
--- a/lantz/qt/widgets/nonnumeric.py
+++ b/lantz/qt/widgets/nonnumeric.py
@@ -31,7 +31,7 @@ class QComboBoxMixin(WidgetMixin):
         widget.valueChanged = widget.currentIndexChanged
 
     def value(self):
-        return self.currentText()
+        return self.__values_dict[self.currentText()]
 
     def setValue(self, value):
         if value is MISSING or value is UNSET:
@@ -48,10 +48,9 @@ class QComboBoxMixin(WidgetMixin):
         super().bind_feat(feat)
         if isinstance(self._feat.values, dict):
             self.__values = list(self._feat.values.keys())
-        elif isinstance(self._feat.values, set):
-            self.__values = list(self._feat.values)
         else:
-            self.__values = list(self.__values)
+            self.__values = list(self._feat.values)
+        self.__values_dict = dict([(str(value), value) for value in self.__values])
         self.clear()
         self.addItems([str(value) for value in self.__values])
 

--- a/lantz/qt/widgets/nonnumeric.py
+++ b/lantz/qt/widgets/nonnumeric.py
@@ -48,6 +48,8 @@ class QComboBoxMixin(WidgetMixin):
         super().bind_feat(feat)
         if isinstance(self._feat.values, dict):
             self.__values = list(self._feat.values.keys())
+        elif isinstance(self._feat.values, set):
+            self.__values = list(self._feat.values)
         else:
             self.__values = list(self.__values)
         self.clear()


### PR DESCRIPTION
Changed the ComboBox bind_feat method to include the possibility of taking non dict feats and added the possibility that non string values. To do that, I added an internal dictionary for the QComboBoxMixin, that maps between the string and the non-string value.