### PR TITLE
Arreglado el import de la Base Abstracta de Collections.Mapping para python 3.10+

### DIFF
--- a/lantz/qt/utils/docscrape.py
+++ b/lantz/qt/utils/docscrape.py
@@ -117,7 +117,7 @@ class ParseError(Exception):
         return message
 
 
-class NumpyDocString(collections.Mapping):
+class NumpyDocString(collections.abc.Mapping):
     """Parses a numpydoc string to an abstract representation
 
     Instances define a mapping from section title to structured data.


### PR DESCRIPTION
De la documentacion de python

> For example, using collections.Mapping instead of collections.abc.Mapping emits a [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning) since Python 3.3, released in 2012.

En python 3.10 removieron el collections.Mapping, este pull request hace el arreglo para que funcione.